### PR TITLE
Renaming to old package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "neoan3/cli",
+    "name": "neoan3/neoan3",
     "homepage": "https://neoan3.rocks",
     "description": "official neoan3 cli",
     "type": "library",


### PR DESCRIPTION
As backwards compatibility is achieved, renaming to main package mitigates confusion